### PR TITLE
Fix "field" in parseTar to use len parameter

### DIFF
--- a/kioku.cabal
+++ b/kioku.cabal
@@ -2,7 +2,7 @@
 --  see http://haskell.org/cabal/users-guide/
 
 name:                kioku
-version:             0.1.1.2
+version:             0.1.2.0
 synopsis:            A library for indexing and querying static datasets on disk
 -- description:         
 homepage:            http://github.com/flipstone/kioku

--- a/src/Database/Kioku/Core.hs
+++ b/src/Database/Kioku/Core.hs
@@ -213,14 +213,14 @@ splitCList total bs0 finish =
 -- during the import.
 --
 parseTar :: (FilePath -> LBS.ByteString -> CList BS.ByteString a -> a) -> a -> LBS.ByteString -> a
-parseTar handler done "" = done
-parseTar handler done bytes | bytes == (LBS.replicate 1024 '\0') = done
+parseTar _ done "" = done
+parseTar _ done bytes | bytes == (LBS.replicate 1024 '\0') = done
 parseTar handler done bytes =
-  let field off len = LBS.takeWhile (/= '\0') $ LBS.take 100 $ LBS.drop off bytes
-      name      = field   0 100
-      size      = field 124  12
-      typ       = field 156   1
-      prefix    = field 345 155
+  let tarField off len = LBS.takeWhile (/= '\0') $ LBS.take len $ LBS.drop off bytes
+      name      = tarField   0 100
+      size      = tarField 124  12
+      typ       = tarField 156   1
+      prefix    = tarField 345 155
       sizeInt   = read ("0o" ++ LBS.unpack size)
       dataStart = LBS.drop 512 bytes
 


### PR DESCRIPTION
The "field" method that was defined in parseTar
didn't use the length parameter that was being
passed to it. This fix addresses that.

Further, this changes the name of "field" to
"tarField" so it doesn't shadow the "field"
method being imported from Memorizable.

Lastly, the "handler" parameter wasn't being used
by parseTar" in the first two definitions of it,
so that named paramter has been replaced with an
underscore.