### PR TITLE
[ch15836] New Kioku query type for keyAllHitsAlong

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -50,7 +50,7 @@ printCities cities =
     CBS.putStr   $ cityLng city
     CBS.putStrLn $ ")"
 
-data City = City 
+data City = City
   { cityName :: BS.ByteString
   , cityLat :: BS.ByteString
   , cityLng :: BS.ByteString

--- a/kioku.cabal
+++ b/kioku.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8467feab6f107122a933ea46bd087b078874c22a75a05d581609935b403a7d8c
+-- hash: 7075b1bb2c1f3aa5fd3efae9cec11fd5e64ae23cbf3f3ca3aaac2b1dfeddce04
 
 name:           kioku
-version:        0.1.2.1
+version:        0.1.2.2
 synopsis:       A library for indexing and querying static datasets on disk
 category:       Database
 homepage:       http://github.com/flipstone/kioku

--- a/kioku.cabal
+++ b/kioku.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7075b1bb2c1f3aa5fd3efae9cec11fd5e64ae23cbf3f3ca3aaac2b1dfeddce04
+-- hash: dfbd46357b7e54321be6177df42f76ba21b1ed5b476ebed362f98bd6db8ca265
 
 name:           kioku
 version:        0.1.2.2
@@ -61,6 +61,7 @@ executable kioku-benchmarks
   build-depends:
       base >=4.8 && <4.13
     , bytestring
+    , deepseq
     , kioku
     , time
     , zlib

--- a/kioku.cabal
+++ b/kioku.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8554b891f12a160b185ef415bc9c759684c9207b11c6f4aec488830cb921c311
+-- hash: 7075b1bb2c1f3aa5fd3efae9cec11fd5e64ae23cbf3f3ca3aaac2b1dfeddce04
 
 name:           kioku
 version:        0.1.2.2
@@ -41,7 +41,6 @@ library
     , containers
     , cryptohash
     , directory
-    , dlist
     , filepath
     , mmap
     , reinterpret-cast

--- a/kioku.cabal
+++ b/kioku.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7075b1bb2c1f3aa5fd3efae9cec11fd5e64ae23cbf3f3ca3aaac2b1dfeddce04
+-- hash: 8554b891f12a160b185ef415bc9c759684c9207b11c6f4aec488830cb921c311
 
 name:           kioku
 version:        0.1.2.2
@@ -41,6 +41,7 @@ library
     , containers
     , cryptohash
     , directory
+    , dlist
     , filepath
     , mmap
     , reinterpret-cast

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: kioku
-version: '0.1.2.1'
+version: '0.1.2.2'
 synopsis: A library for indexing and querying static datasets on disk
 category: Database
 author: Flipstone Technology Partners

--- a/package.yaml
+++ b/package.yaml
@@ -36,7 +36,6 @@ library:
   - tar
   - temporary
   - text
-  - dlist
 executables:
   kioku-benchmarks:
     main: benchmarks/Main.hs

--- a/package.yaml
+++ b/package.yaml
@@ -45,6 +45,7 @@ executables:
     dependencies:
     - time
     - kioku
+    - deepseq
   kioku-example:
     main: example/Main.hs
     default-extensions:

--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,7 @@ library:
   - tar
   - temporary
   - text
+  - dlist
 executables:
   kioku-benchmarks:
     main: benchmarks/Main.hs

--- a/src/Database/Kioku/Core.hs
+++ b/src/Database/Kioku/Core.hs
@@ -7,7 +7,7 @@ module Database.Kioku.Core
   , createDataSet
   , createIndex
   , createSchema
-  , query, keyExact, keyExactIn, keyPrefix, firstStopAlong
+  , query, keyExact, keyExactIn, keyPrefix, keyAllHitsAlong, firstStopAlong
 
   , gcKiokuDB, validateDB
   , packKiokuDB, exportKiokuDB

--- a/src/Database/Kioku/Internal/Query.hs
+++ b/src/Database/Kioku/Internal/Query.hs
@@ -1,6 +1,10 @@
 module Database.Kioku.Internal.Query
   ( KiokuQuery
-  , keyExact, keyExactIn, keyPrefix, firstStopAlong
+  , keyExact
+  , keyExactIn
+  , keyPrefix
+  , keyAllHitsAlong
+  , firstStopAlong
   , runQuery
   ) where
 
@@ -20,6 +24,9 @@ keyExactIn key = KQ (trieLookupMany key)
 
 keyPrefix :: BS.ByteString -> KiokuQuery
 keyPrefix key = KQ (trieMatch key)
+
+keyAllHitsAlong :: BS.ByteString -> KiokuQuery
+keyAllHitsAlong path = KQ (trieAllHitsAlong path)
 
 firstStopAlong :: BS.ByteString -> KiokuQuery
 firstStopAlong path = KQ (trieFirstStopAlong path)

--- a/test/QueryTest.hs
+++ b/test/QueryTest.hs
@@ -95,6 +95,40 @@ test_queries =
             , queryTestQuery    = keyExactIn $ testDataKey <$> [ TestData "USNY", TestData "USN" ]
             , queryTestExpected = [ TestData "USNY", TestData "USN" ]
             }
+
+    , testCase "finds multiple results for keyAllHitsAlong with single-character nodes" $
+        runQueryTest $
+          QueryTest
+            { queryTestData     = [ TestData "1", TestData "15", TestData "16", TestData "17", TestData "165" ]
+            , queryTestQuery    = keyAllHitsAlong . testDataKey $ TestData "168"
+            , queryTestExpected = [ TestData "1", TestData "16" ]
+            }
+
+    , testCase "finds multiple results for keyAllHitsAlong with multi-character nodes" $
+        runQueryTest $
+          QueryTest
+            { queryTestData     = [ TestData "101", TestData "1015", TestData "1016", TestData "1017", TestData "10165" ]
+            , queryTestQuery    = keyAllHitsAlong . testDataKey $ TestData "10168"
+            , queryTestExpected = [ TestData "101", TestData "1016" ]
+            }
+
+    , testCase "finds result for keyPrefix with multi-character nodes" $
+        runQueryTest $
+          QueryTest
+            { queryTestData     = [ TestData "101", TestData "1015", TestData "1016", TestData "1017", TestData "10165" ]
+            , queryTestQuery    = keyPrefix . testDataKey $ TestData "1016"
+            , queryTestExpected = [ TestData "1016", TestData "10165" ]
+            }
+
+    , testCase "finds results for keyExact with multi-character nodes" $
+        runQueryTest $
+          QueryTest
+            { queryTestData     = [ TestData "101", TestData "1015", TestData "1016", TestData "1017", TestData "10165" ]
+            , queryTestQuery    = keyExact . testDataKey $ TestData "1016"
+            , queryTestExpected = [ TestData "1016" ]
+            }
+
+
     ]
 
 data QueryTest =

--- a/test/QueryTest.hs
+++ b/test/QueryTest.hs
@@ -107,9 +107,9 @@ test_queries =
     , testCase "finds multiple results for keyAllHitsAlong with multi-character nodes" $
         runQueryTest $
           QueryTest
-            { queryTestData     = [ TestData "101", TestData "1015", TestData "1016", TestData "1017", TestData "10165" ]
-            , queryTestQuery    = keyAllHitsAlong . testDataKey $ TestData "10168"
-            , queryTestExpected = [ TestData "101", TestData "1016" ]
+            { queryTestData     = [ TestData "101", TestData "1010", TestData "101005", TestData "101006", TestData "101007", TestData "1010065", TestData "1010068" ]
+            , queryTestQuery    = keyAllHitsAlong . testDataKey $ TestData "1010068"
+            , queryTestExpected = [ TestData "101", TestData "1010", TestData "101006", TestData "1010068" ]
             }
 
     , testCase "finds result for keyPrefix with multi-character nodes" $


### PR DESCRIPTION
Query returning all hits in a tree with key values possibly of different lengths

Co-authored-by: Aaron <aaron@flipstone.com>
Co-authored-by: Paul <paul@flipstone.com>

<img width="557" alt="Screen Shot 2019-05-28 at 10 46 38 AM" src="https://user-images.githubusercontent.com/16817102/58492145-f5e22880-8135-11e9-857c-1616b1a014c3.png">
