### PR TITLE
Avoid incomplete pattern match

### DIFF
--- a/src/Database/Kioku/Internal/TrieIndex.hs
+++ b/src/Database/Kioku/Internal/TrieIndex.hs
@@ -143,10 +143,10 @@ mkInsert (MultiKey prefix kids isEnd) key =
        in MultiKey newPrefix [newMultiKey, oldMultiKey] False
 
 mkMultiKey :: [BS.ByteString] -> MultiKey
-mkMultiKey [] = error "Can't build MultiKey with no keys!"
 mkMultiKey keys =
-  let (first:rest) = nub (sortBy (flip compare) keys)
-   in foldl' mkInsert (MultiKey first [] True) rest
+  case nub (sortBy (flip compare) keys) of
+    [] -> error "Can't build MultiKey with no keys!"
+    first:rest -> foldl' mkInsert (MultiKey first [] True) rest
 
 data DecodedNode = DecodedNode {
     d_arc :: BS.ByteString


### PR DESCRIPTION
Since we have `-Wall` and `-Werror` enabled, GHC 9.2 complains about
this being an incomplete pattern match.

This version of GHC cannot infer that the list can't be empty after
running 'sortBy' and 'nub' on a non-empty list.

To avoid checking twice whether it is empty, we move the check until
after 'sortBy' and 'nub' have been run. Since we know that these
functions can work on empty lists, we now have equivalent behaviour,
even though it may be a tiny bit slower. This is a fatal error anyway,
so it shouldn't ever be called in a situation where performance matters.