### PR TITLE
[sc-24332] Adds Memorizable instances for List and NonEmpty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ example/data
 .DS_Store
 docker-compose.override.yml
 .stack-work
-kioku.cabal

--- a/kioku.cabal
+++ b/kioku.cabal
@@ -1,0 +1,105 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.1.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 6a61d874c65ecdb1952d812b5b15c7fc7474443f21eb19da30623f3abbda8175
+
+name:           kioku
+version:        0.1.2.3
+synopsis:       A library for indexing and querying static datasets on disk
+category:       Database
+homepage:       http://github.com/flipstone/kioku
+author:         Flipstone Technology Partners
+maintainer:     development@flipstone.com
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+
+library
+  exposed-modules:
+      Database.Kioku
+      Database.Kioku.Core
+      Database.Kioku.Memorizable
+      Database.Kioku.Schema
+  other-modules:
+      Database.Kioku.Internal.Buffer
+      Database.Kioku.Internal.BufferMap
+      Database.Kioku.Internal.KiokuDB
+      Database.Kioku.Internal.Query
+      Database.Kioku.Internal.TrieIndex
+      Paths_kioku
+  hs-source-dirs:
+      src
+  default-extensions: OverloadedStrings
+  ghc-options: -Wall -fprof-auto -Werror
+  build-depends:
+      base >=4.8
+    , base16-bytestring
+    , bytestring
+    , containers
+    , cryptohash
+    , directory
+    , filepath
+    , mmap
+    , reinterpret-cast
+    , tar
+    , temporary
+    , text
+    , vector
+    , vector-algorithms >=0.8.0.1
+    , zlib
+  default-language: Haskell2010
+
+executable kioku-benchmarks
+  main-is: benchmarks/Main.hs
+  other-modules:
+      Paths_kioku
+  default-extensions: OverloadedStrings
+  ghc-options: -Wall -fprof-auto -Werror -O3 -rtsopts
+  build-depends:
+      base >=4.8
+    , bytestring
+    , deepseq
+    , kioku
+    , time
+    , zlib
+  default-language: Haskell2010
+
+executable kioku-example
+  main-is: example/Main.hs
+  other-modules:
+      Paths_kioku
+  default-extensions: OverloadedStrings RecordWildCards
+  ghc-options: -Wall -fprof-auto -Werror -O3
+  build-depends:
+      base >=4.8
+    , bytestring
+    , kioku
+    , zlib
+  default-language: Haskell2010
+
+test-suite kioku-test
+  type: exitcode-stdio-1.0
+  main-is: Driver.hs
+  other-modules:
+      QueryTest
+      Paths_kioku
+  hs-source-dirs:
+      test
+  default-extensions: OverloadedStrings
+  ghc-options: -Wall -fprof-auto -Werror -O3
+  build-depends:
+      base >=4.8
+    , bytestring
+    , containers
+    , deepseq
+    , hedgehog
+    , kioku
+    , tasty
+    , tasty-discover
+    , tasty-hedgehog
+    , tasty-hunit
+    , zlib
+  default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: kioku
-version: '0.1.2.2'
+version: '0.1.2.3'
 synopsis: A library for indexing and querying static datasets on disk
 category: Database
 author: Flipstone Technology Partners

--- a/src/Database/Kioku/Memorizable.hs
+++ b/src/Database/Kioku/Memorizable.hs
@@ -36,14 +36,15 @@ module Database.Kioku.Memorizable
   , MemorizeLength, RecallLength, LengthSize
   ) where
 
-import qualified  Data.ByteString as BS
-import qualified  Data.ByteString.Unsafe as UBS
-import            Data.Bits
-import            Data.Int
-import            Data.ReinterpretCast
-import            Data.Text (Text)
-import qualified  Data.Text.Encoding as E
-import            Data.Word
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Unsafe as UBS
+import           Data.Bits
+import           Data.Int
+import qualified Data.List.NonEmpty as NE
+import           Data.ReinterpretCast
+import           Data.Text (Text)
+import qualified Data.Text.Encoding as E
+import           Data.Word
 
 class Memorizable a where
   memorize :: a -> BS.ByteString
@@ -410,3 +411,21 @@ instance (Memorizable a, Memorizable b) => Memorizable (Either a b) where
     1 -> Right $ recall $ BS.drop 1 bs
     n -> error $ "recall: Invalid Either constructor index: " ++ show n
 
+instance Memorizable a => Memorizable [a] where
+  memorize = lengthPrefix255 . map memorize
+  recall = recallItems []
+
+instance Memorizable a => Memorizable (NE.NonEmpty a) where
+  memorize = lengthPrefix255 . map memorize . NE.toList
+  recall bs =
+    case NE.nonEmpty $ recallItems [] bs of
+      Just ne -> ne
+      Nothing -> error "Tried to recall an empty list into a NonEmpty"
+
+recallItems :: Memorizable a => [a] -> BS.ByteString -> [a]
+recallItems items bs
+  | bs == BS.empty = items
+  | otherwise      = recallItems (items ++ [recall currSection]) rest
+      where
+        lengthOfCurrentElem = fromIntegral $ BS.head bs
+        (currSection, rest) = BS.splitAt (lengthOfCurrentElem) $ BS.tail bs

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.26
+resolver: lts-14.27
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
We frequently have lists and now NonEmpty lists on Memorizable types
and we write one-off implementations for each case. These instances
will keep up from having to rewrite those.