### PR TITLE
Unignores cabal file for Kioku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ example/data
 .DS_Store
 docker-compose.override.yml
 .stack-work
-kioku.cabal

--- a/kioku.cabal
+++ b/kioku.cabal
@@ -1,0 +1,105 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.1.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 6a61d874c65ecdb1952d812b5b15c7fc7474443f21eb19da30623f3abbda8175
+
+name:           kioku
+version:        0.1.2.3
+synopsis:       A library for indexing and querying static datasets on disk
+category:       Database
+homepage:       http://github.com/flipstone/kioku
+author:         Flipstone Technology Partners
+maintainer:     development@flipstone.com
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+
+library
+  exposed-modules:
+      Database.Kioku
+      Database.Kioku.Core
+      Database.Kioku.Memorizable
+      Database.Kioku.Schema
+  other-modules:
+      Database.Kioku.Internal.Buffer
+      Database.Kioku.Internal.BufferMap
+      Database.Kioku.Internal.KiokuDB
+      Database.Kioku.Internal.Query
+      Database.Kioku.Internal.TrieIndex
+      Paths_kioku
+  hs-source-dirs:
+      src
+  default-extensions: OverloadedStrings
+  ghc-options: -Wall -fprof-auto -Werror
+  build-depends:
+      base >=4.8
+    , base16-bytestring
+    , bytestring
+    , containers
+    , cryptohash
+    , directory
+    , filepath
+    , mmap
+    , reinterpret-cast
+    , tar
+    , temporary
+    , text
+    , vector
+    , vector-algorithms >=0.8.0.1
+    , zlib
+  default-language: Haskell2010
+
+executable kioku-benchmarks
+  main-is: benchmarks/Main.hs
+  other-modules:
+      Paths_kioku
+  default-extensions: OverloadedStrings
+  ghc-options: -Wall -fprof-auto -Werror -O3 -rtsopts
+  build-depends:
+      base >=4.8
+    , bytestring
+    , deepseq
+    , kioku
+    , time
+    , zlib
+  default-language: Haskell2010
+
+executable kioku-example
+  main-is: example/Main.hs
+  other-modules:
+      Paths_kioku
+  default-extensions: OverloadedStrings RecordWildCards
+  ghc-options: -Wall -fprof-auto -Werror -O3
+  build-depends:
+      base >=4.8
+    , bytestring
+    , kioku
+    , zlib
+  default-language: Haskell2010
+
+test-suite kioku-test
+  type: exitcode-stdio-1.0
+  main-is: Driver.hs
+  other-modules:
+      QueryTest
+      Paths_kioku
+  hs-source-dirs:
+      test
+  default-extensions: OverloadedStrings
+  ghc-options: -Wall -fprof-auto -Werror -O3
+  build-depends:
+      base >=4.8
+    , bytestring
+    , containers
+    , deepseq
+    , hedgehog
+    , kioku
+    , tasty
+    , tasty-discover
+    , tasty-hedgehog
+    , tasty-hunit
+    , zlib
+  default-language: Haskell2010


### PR DESCRIPTION
We previously ignored the cabal file for Kioku because it was submoduled
into projects with different GHC versions causing spurious changes to
that file. Now we don't submodule it so it should have its own cabal
file checked in since that's used by the projects that build it.