### PR TITLE
[sc-24388] Eliminates memorize/recallEnum

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  dev:
+  kioku:
     environment:
       STACK_ROOT: /stack-root
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  dev:
+  kioku:
     image: flipstone/stack:v2-1.9.3
     volumes:
       - .:/kioku

--- a/kioku.cabal
+++ b/kioku.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.1.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0786dc62f935374d9f1d1eef2e4feb0fa75846c3f91e2c1c3ff06e14896b2847
+-- hash: d4347457569a89f2ff6bc6597eb7a9855f868a26721ce3f5236f326e6fd0691e
 
 name:           kioku
 version:        0.1.2.3
@@ -32,7 +32,8 @@ library
       Paths_kioku
   hs-source-dirs:
       src
-  default-extensions: OverloadedStrings
+  default-extensions:
+      OverloadedStrings
   ghc-options: -Wall -fprof-auto -Werror
   build-depends:
       base >=4.8
@@ -57,7 +58,8 @@ executable kioku-benchmarks
   main-is: benchmarks/Main.hs
   other-modules:
       Paths_kioku
-  default-extensions: OverloadedStrings
+  default-extensions:
+      OverloadedStrings
   ghc-options: -Wall -fprof-auto -Werror -O3 -rtsopts
   build-depends:
       base >=4.8
@@ -72,7 +74,9 @@ executable kioku-example
   main-is: example/Main.hs
   other-modules:
       Paths_kioku
-  default-extensions: OverloadedStrings RecordWildCards
+  default-extensions:
+      OverloadedStrings
+      RecordWildCards
   ghc-options: -Wall -fprof-auto -Werror -O3
   build-depends:
       base >=4.8
@@ -89,7 +93,8 @@ test-suite kioku-test
       Paths_kioku
   hs-source-dirs:
       test
-  default-extensions: OverloadedStrings
+  default-extensions:
+      OverloadedStrings
   ghc-options: -Wall -fprof-auto -Werror -O3
   build-depends:
       base >=4.8

--- a/kioku.cabal
+++ b/kioku.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.31.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d4347457569a89f2ff6bc6597eb7a9855f868a26721ce3f5236f326e6fd0691e
+-- hash: 35eaf550322ff144c395f4f82e21461adb6d938bf11ecbe41988cf156487331f
 
 name:           kioku
-version:        0.1.2.3
+version:        0.1.3.0
 synopsis:       A library for indexing and querying static datasets on disk
 category:       Database
 homepage:       http://github.com/flipstone/kioku
@@ -32,8 +32,7 @@ library
       Paths_kioku
   hs-source-dirs:
       src
-  default-extensions:
-      OverloadedStrings
+  default-extensions: OverloadedStrings
   ghc-options: -Wall -fprof-auto -Werror
   build-depends:
       base >=4.8
@@ -58,8 +57,7 @@ executable kioku-benchmarks
   main-is: benchmarks/Main.hs
   other-modules:
       Paths_kioku
-  default-extensions:
-      OverloadedStrings
+  default-extensions: OverloadedStrings
   ghc-options: -Wall -fprof-auto -Werror -O3 -rtsopts
   build-depends:
       base >=4.8
@@ -74,9 +72,7 @@ executable kioku-example
   main-is: example/Main.hs
   other-modules:
       Paths_kioku
-  default-extensions:
-      OverloadedStrings
-      RecordWildCards
+  default-extensions: OverloadedStrings RecordWildCards
   ghc-options: -Wall -fprof-auto -Werror -O3
   build-depends:
       base >=4.8
@@ -93,8 +89,7 @@ test-suite kioku-test
       Paths_kioku
   hs-source-dirs:
       test
-  default-extensions:
-      OverloadedStrings
+  default-extensions: OverloadedStrings
   ghc-options: -Wall -fprof-auto -Werror -O3
   build-depends:
       base >=4.8

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: kioku
-version: '0.1.2.3'
+version: '0.1.3.0'
 synopsis: A library for indexing and querying static datasets on disk
 category: Database
 author: Flipstone Technology Partners

--- a/src/Database/Kioku/Memorizable.hs
+++ b/src/Database/Kioku/Memorizable.hs
@@ -21,7 +21,6 @@ module Database.Kioku.Memorizable
 
   , memorizeText, recallText
   , memorizeNonEmptyText, recallNonEmptyText
-  , memorizeEnum, recallEnum
 
   , roll
   , unroll
@@ -195,14 +194,6 @@ memorizeFloat = memorizeWord32 . floatToWord
 {-# INLINE recallFloat #-}
 recallFloat :: BS.ByteString -> Float
 recallFloat = wordToFloat . recallWord32
-
-{-# INLINE memorizeEnum #-}
-memorizeEnum :: Enum a => a -> BS.ByteString
-memorizeEnum = memorizeInteger . fromIntegral . fromEnum
-
-{-# INLINE recallEnum #-}
-recallEnum :: Enum a => BS.ByteString -> a
-recallEnum = toEnum . fromIntegral . recallInteger
 
 memorizeInteger :: Integer -> BS.ByteString
 memorizeInteger n = {-# SCC memorizeInteger #-}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,22 +5,29 @@
 
 packages:
 - completed:
+    hackage: hedgehog-1.0.5@sha256:85a2d8df595c91b815e9d2ef7734189d7028ce16212e83f35b2221807d87770b,4368
     pantry-tree:
       sha256: 9189de078d9bddcf9b2bf6e6a11a7dbcc2fec962b081e0a4b58301b14f6e25a7
       size: 2575
-    hackage: hedgehog-1.0.5@sha256:85a2d8df595c91b815e9d2ef7734189d7028ce16212e83f35b2221807d87770b,4368
   original:
     hackage: hedgehog-1.0.5@sha256:85a2d8df595c91b815e9d2ef7734189d7028ce16212e83f35b2221807d87770b,4368
 - completed:
+    hackage: non-empty-text-0.1.1@sha256:5c757d9b27c3ef61f1620613a5e105a870801ad1addef7ade62a2ca1798fea9f,1996
+    pantry-tree:
+      sha256: b0ae540112e158be055f66492a4a87d9fd3c661166d77339e174ea6fa570c728
+      size: 347
+  original:
+    hackage: non-empty-text-0.1.1@sha256:5c757d9b27c3ef61f1620613a5e105a870801ad1addef7ade62a2ca1798fea9f,1996
+- completed:
+    hackage: tasty-hedgehog-1.1.0.0@sha256:e1289602588b87caa809bd58f8af169738a37dcd8d579eb4a79a540a788c8f22,1803
     pantry-tree:
       sha256: 18a877911c5544030afd43299a01fb5c7f6f6ab60de3d41978b25000e513d0c3
       size: 330
-    hackage: tasty-hedgehog-1.1.0.0@sha256:e1289602588b87caa809bd58f8af169738a37dcd8d579eb4a79a540a788c8f22,1803
   original:
     hackage: tasty-hedgehog-1.1.0.0@sha256:e1289602588b87caa809bd58f8af169738a37dcd8d579eb4a79a540a788c8f22,1803
 snapshots:
 - completed:
-    sha256: ecb02ee16829df8d7219e7d7fe6c310819820bf335b0b9534bce84d3ea896684
-    size: 499889
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/26.yaml
-  original: lts-13.26
+    sha256: 7ea31a280c56bf36ff591a7397cc384d0dff622e7f9e4225b47d8980f019a0f0
+    size: 524996
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/27.yaml
+  original: lts-14.27

--- a/tasks/dev-shell
+++ b/tasks/dev-shell
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker attach kioku-dev || docker-compose run --name kioku-dev --rm --service-ports --use-aliases kioku bash


### PR DESCRIPTION
This removes the enum Memorization helper functions. We've been burned
by these too many times when we change an enum instance and don't think
about re-ingesting the related data.

We'll use explicit conversions for them instead.
