### PR TITLE
Adds namespace support to Kioku

### DIFF
--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -69,6 +69,9 @@ benchmarkData =
   , TestData "1010068"
   ]
 
+benchNamespace :: KiokuNamespace
+benchNamespace = KiokuNamespace "kioku_bench"
+
 benchQueries :: Int -> IO ()
 benchQueries count = do
   let
@@ -80,15 +83,15 @@ benchQueries count = do
       ]
 
   withKiokuDB defaultKiokuPath $ \db -> do
-    void $ createDataSet "kioku_bench" benchmarkData db
-    createIndex "kioku_bench" "kioku_bench.index" testDataKey db
+    void $ createDataSet benchNamespace "kioku_bench" benchmarkData db
+    createIndex benchNamespace "kioku_bench" "kioku_bench.index" testDataKey db
 
     for_ queries $ \(queryName, q) -> do
       putStr $ queryName ++ " (" ++ show count ++ ")"
       start <- getPOSIXTime
 
       _ <- replicateM count $ do
-        results <- query "kioku_bench.index" q db :: IO [TestData]
+        results <- query benchNamespace "kioku_bench.index" q db :: IO [TestData]
         results `deepseq` pure ()
 
       finish <- getPOSIXTime

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -20,15 +20,15 @@ main = do
 
         count <- do
           cities <- loadCities "example/data/cities.txt.gz"
-          createDataSet "cities" cities db
+          createDataSet exampleNamespace "cities" cities db
 
         putStrLn $ "Done... loaded " ++ show count ++ " cities"
       ("cities" : "index" : _) -> do
         putStrLn $ "Indexing cities by name."
-        createIndex "cities" "cities.name" cityName db
+        createIndex exampleNamespace "cities" "cities.name" cityName db
         putStrLn $ "Done... "
       ("cities" : "query" : name : _) -> do
-        cities <- query "cities.name" (keyPrefix $ CBS.pack name) db
+        cities <- query exampleNamespace "cities.name" (keyPrefix $ CBS.pack name) db
         printCities cities
       _ -> do
         putStrLn $ "Unknown command: " ++ unwords args
@@ -43,6 +43,9 @@ printCities cities =
     CBS.putStr $ ","
     CBS.putStr $ cityLng city
     CBS.putStrLn $ ")"
+
+exampleNamespace :: KiokuNamespace
+exampleNamespace = KiokuNamespace "example"
 
 data City = City
   { cityName :: BS.ByteString

--- a/src/Database/Kioku/Core.hs
+++ b/src/Database/Kioku/Core.hs
@@ -5,6 +5,7 @@ module Database.Kioku.Core
   , DataSetName
   , IndexName
   , SchemaName
+  , KiokuNamespace (..)
   , openKiokuDB
   , defaultKiokuPath
   , closeKiokuDB
@@ -18,31 +19,19 @@ module Database.Kioku.Core
   , keyPrefix
   , keyAllHitsAlong
   , gcKiokuDB
-  , validateDB
-  , packKiokuDB
-  , exportKiokuDB
-  , unpackKiokuDB
-  , importKiokuDB
   ) where
 
-import qualified Codec.Archive.Tar as Tar
-import qualified Codec.Compression.GZip as GZ
 import Control.Exception
-import Control.Monad
 import Crypto.Hash.SHA256
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.Foldable
 import Data.IORef
-import Data.Int
-import Data.List (isInfixOf, isPrefixOf, (\\))
-import Data.Maybe
+import Data.List ((\\))
 import Data.Traversable
 import System.Directory
-import System.FilePath
 import System.IO
-import System.IO.Temp
 
 import Database.Kioku.Internal.BufferMap
 import Database.Kioku.Internal.KiokuDB
@@ -64,52 +53,13 @@ openKiokuDB path = do
     (createDirectoryIfMissing True)
     [ dataDir db
     , tmpDir db
-    , dataSetObjDir db
-    , indexObjDir db
-    , schemaObjDir db
+    , objDir db
     ]
 
   pure db
 
 closeKiokuDB :: KiokuDB -> IO ()
 closeKiokuDB = closeBuffers . bufferMap
-
-validateDB :: KiokuDB -> IO [KiokuException]
-validateDB db = do
-  dataErrs <- validateDataFiles
-  indexErrs <- validateIndexFiles
-  schemaErrs <- validateSchemaFiles
-
-  pure $ catMaybes $ dataErrs ++ indexErrs ++ schemaErrs
- where
-  validateDataFiles = do
-    paths <- listDirectoryContents $ dataDir db
-
-    for paths $ \name -> do
-      let
-        bsName = BS.pack name
-        fileName = dataFilePath db bsName
-
-      sha <- hashFile fileName
-
-      pure $
-        if sha == bsName
-          then Nothing
-          else Just $ KiokuException $ "Data file " ++ name ++ " is corrupt!"
-
-  validateIndexFiles = do
-    paths <- listDirectoryContents $ indexObjDir db
-
-    for paths $ \name -> do
-      index <- readIndexFile name db
-      pure $ either Just (const Nothing) index
-
-  validateSchemaFiles = do
-    paths <- listDirectoryContents $ schemaObjDir db
-
-    for paths $ \name -> do
-      index <- readSchemaFile name db
-      pure $ either Just (const Nothing) index
 
 gcKiokuDB :: KiokuDB -> IO ()
 gcKiokuDB db = do
@@ -125,168 +75,42 @@ gcKiokuDB db = do
   traverse_ removeFile unusedFiles
  where
   readHashRefs = do
-    dataSets <- readDataSets
-    indexes <- readIndexes
-    schemaRefs <- readSchemas
+    namespaces <- listDirectoryContents $ objDir db
+    hashRefs <- mapM readHashRefsFor $ fmap KiokuNamespace namespaces
+    pure $ concat hashRefs
+
+  readHashRefsFor namespace = do
+    dataSets <- readDataSetsFor namespace
+    indexes <- readIndexesFor namespace
+    schemaRefs <- readSchemasFor namespace
     pure (dataSets ++ concat indexes ++ concat schemaRefs)
 
-  readDataSets = do
-    paths <- listDirectoryContents $ dataSetObjDir db
+  readDataSetsFor namespace = do
+    paths <- listDirectoryContents $ dataSetObjDir db namespace
 
     for paths $ \name -> do
-      dataSetFile <- readDataSetFile name db
+      dataSetFile <- readDataSetFile namespace name db
       pure (dataSetHash dataSetFile)
 
   indexRefs index = [indexHash index, dataHash index]
 
-  readIndexes = do
-    paths <- listDirectoryContents $ indexObjDir db
+  readIndexesFor namespace = do
+    paths <- listDirectoryContents $ indexObjDir db namespace
 
     for paths $ \name -> do
-      indexFile <- throwErrors $ readIndexFile name db
+      indexFile <- throwErrors $ readIndexFile namespace name db
       pure $ indexRefs indexFile
 
-  readSchemas = do
-    paths <- listDirectoryContents $ schemaObjDir db
+  readSchemasFor namespace = do
+    paths <- listDirectoryContents $ schemaObjDir db namespace
 
     for paths $ \name -> do
-      schema <- throwErrors $ readSchemaFile name db
+      schema <- throwErrors $ readSchemaFile namespace name db
       pure $ concatMap (indexRefs . indexContent) $ schemaIndexes schema
 
 listDirectoryContents :: FilePath -> IO [FilePath]
 listDirectoryContents dir =
   filter (not . (`elem` [".", ".."])) <$> getDirectoryContents dir
-
-packKiokuDB :: KiokuDB -> IO LBS.ByteString
-packKiokuDB db = do
-  entries <- Tar.pack (rootDir db) [dataPath, dataSetObjPath, indexObjPath, schemaObjPath]
-  pure $ GZ.compress $ Tar.write entries
-
-exportKiokuDB :: FilePath -> KiokuDB -> IO ()
-exportKiokuDB path db = packKiokuDB db >>= LBS.writeFile path
-
--- You should call validateDB after using this!
-unpackKiokuDB :: LBS.ByteString -> KiokuDB -> IO ()
-unpackKiokuDB gzBytes db = do
-  parseTar handleEntry (pure ()) $ GZ.decompress gzBytes
- where
-  handleEntry tarPath typ stream =
-    case typ of
-      "0" -> do
-        checkPathSecurity tarPath
-        let
-          path = rootDir db </> tarPath
-        join (writeBytes path stream)
-      _ -> do
-        clistEnd stream
-
-  writeBytes path stream = do
-    createDirectoryIfMissing True (takeDirectory path)
-    bracket
-      (openBinaryFile path WriteMode)
-      hClose
-      (go stream)
-   where
-    go (Done d) _ = pure d
-    go (Stream chunk rest) h = BS.hPut h chunk >> go rest h
-
-  checkPathSecurity p
-    | "/"
-        `isPrefixOf` p
-        || ".."
-          `isInfixOf` p =
-        throwIO $ KiokuException $ "Insecure file path found in kioku import: " ++ p
-    | otherwise = pure ()
-
-data CList a d
-  = Stream a (CList a d)
-  | Done d
-
-clistEnd :: CList a d -> d
-clistEnd (Done d) = d
-clistEnd (Stream _ l) = clistEnd l
-
-splitCList :: Int64 -> LBS.ByteString -> (LBS.ByteString -> d) -> CList BS.ByteString d
-splitCList total bs0 finish =
-  go total $ LBS.toChunks bs0
- where
-  go _ [] = Done (finish $ LBS.fromChunks [])
-  go n chunks | n <= 0 = Done $ finish (LBS.fromChunks chunks)
-  go n (chunk : rest) =
-    if n > fromIntegral (BS.length chunk)
-      then Stream chunk (go (n - fromIntegral (BS.length chunk)) rest)
-      else
-        let
-          (bs, bsr) = BS.splitAt (fromIntegral n) chunk
-        in
-          Stream bs (go 0 (bsr : rest))
-
--- This is a terrible hand coded tar parser that avoids keeping the entire tar
--- entry in ram while writing it to disk. This is useful for us because we have
--- entries on the 100m order, but don't need that much ram to run in general
---
--- Note there is lots of potential badness here! We don't check checksums or
--- anything like it. We assume that validateDB is going to take care of that
--- during the import.
---
-parseTar :: (FilePath -> LBS.ByteString -> CList BS.ByteString a -> a) -> a -> LBS.ByteString -> a
-parseTar _ done "" = done
-parseTar _ done bytes | bytes == (LBS.replicate 1024 '\0') = done
-parseTar handler done bytes =
-  let
-    tarField off len = LBS.takeWhile (/= '\0') $ LBS.take len $ LBS.drop off bytes
-    name = tarField 0 100
-    size = tarField 124 12
-    typ = tarField 156 1
-    prefix = tarField 345 155
-    sizeInt = read ("0o" ++ LBS.unpack size)
-    dataStart = LBS.drop 512 bytes
-
-    stream = splitCList sizeInt dataStart $ \rest ->
-      let
-        (blocks, remainder) = sizeInt `divMod` 512
-        blockSeek = blocks + signum remainder
-        blockPadding = (blockSeek * 512) - sizeInt
-      in
-        parseTar handler done (LBS.drop blockPadding rest)
-
-    path = case prefix of
-      "" -> LBS.unpack name
-      _ -> LBS.unpack prefix </> LBS.unpack name
-  in
-    handler path typ stream
-
-importKiokuDB :: FilePath -> KiokuDB -> IO ()
-importKiokuDB path db = do
-  withTempDirectory (tmpDir db) "import." $ \tmpDBPath -> do
-    withKiokuDB tmpDBPath $ \tmpDB -> do
-      LBS.readFile path >>= flip unpackKiokuDB tmpDB
-
-      errors <- validateDB tmpDB
-
-      case errors of
-        [] -> do
-          let
-            eachFile dir action = listDirectoryContents dir >>= mapM_ action
-            rename check pathFunc name = do
-              let
-                tmpName = pathFunc tmpDB name
-                dbName = pathFunc db name
-
-              checked <- check dbName
-              when checked $ renameFile tmpName dbName
-
-            renameAlways = rename (const $ pure True)
-            renameIfNew = rename (fmap not . doesFileExist)
-
-          eachFile (dataDir tmpDB) (renameIfNew $ \d p -> dataFilePath d (BS.pack p))
-          eachFile (indexObjDir tmpDB) (renameAlways indexObjFile)
-          eachFile (schemaObjDir tmpDB) (renameAlways schemaObjFile)
-        _ -> do
-          let
-            msg = "Found the following errors while validating the db import. The import has been abandoned to avoid corrupting the database."
-            errStrings = map show errors
-          throwIO $ KiokuException $ unlines (msg : errStrings)
 
 withKiokuDB :: FilePath -> (KiokuDB -> IO a) -> IO a
 withKiokuDB path action = do
@@ -296,22 +120,22 @@ withKiokuDB path action = do
 hashFile :: FilePath -> IO BS.ByteString
 hashFile = fmap (Base16.encode . hashlazy) . LBS.readFile
 
-createSchema :: SchemaName -> [IndexName] -> KiokuDB -> IO ()
-createSchema name indexNames db = do
+createSchema :: KiokuNamespace -> SchemaName -> [IndexName] -> KiokuDB -> IO ()
+createSchema namespace name indexNames db = do
   let
-    readSchemaIndex idxName = SchemaIndex idxName <$> (throwErrors $ readIndexFile idxName db)
+    readSchemaIndex idxName = SchemaIndex idxName <$> (throwErrors $ readIndexFile namespace idxName db)
   indexes <- traverse readSchemaIndex indexNames
-  writeSchemaFile name (SchemaFile indexes) db
+  writeSchemaFile namespace name (SchemaFile indexes) db
 
-createDataSet :: Memorizable a => DataSetName -> [a] -> KiokuDB -> IO Int
-createDataSet name as db = do
+createDataSet :: Memorizable a => KiokuNamespace -> DataSetName -> [a] -> KiokuDB -> IO Int
+createDataSet namespace name as db = do
   (tmpFile, h) <- openTempFile (tmpDir db) name
   count <- hWriteRows as h
   hClose h
 
   sha <- hashFile tmpFile
   renameFile tmpFile (dataFilePath db sha)
-  writeDataSetFile name (DataSetFile {dataSetHash = sha}) db
+  writeDataSetFile namespace name (DataSetFile {dataSetHash = sha}) db
   pure count
 
 hWriteRows :: Memorizable a => [a] -> Handle -> IO Int
@@ -337,13 +161,14 @@ hWriteRows as h = do
 
 createIndex ::
   Memorizable a =>
+  KiokuNamespace ->
   DataSetName ->
   IndexName ->
   (a -> BS.ByteString) ->
   KiokuDB ->
   IO ()
-createIndex dataSetName idxName keyFunc db = do
-  dataSetFile <- readDataSetFile dataSetName db
+createIndex namespace dataSetName idxName keyFunc db = do
+  dataSetFile <- readDataSetFile namespace dataSetName db
   dataBuf <- openDataBuffer (dataSetHash dataSetFile) db
   tmpFile <- writeIndex keyFunc dataBuf $ \flushIndex -> do
     (tmpFile, h) <- openTempFile (tmpDir db) idxName
@@ -361,16 +186,17 @@ createIndex dataSetName idxName keyFunc db = do
         , dataHash = dataSetHash dataSetFile
         }
 
-  writeIndexFile idxName indexFile db
+  writeIndexFile namespace idxName indexFile db
 
 query ::
   Memorizable a =>
+  KiokuNamespace ->
   IndexName ->
   KiokuQuery ->
   KiokuDB ->
   IO [a]
-query name kQuery db = do
-  indexFile <- throwErrors $ readIndexFile name db
+query namespace name kQuery db = do
+  indexFile <- throwErrors $ readIndexFile namespace name db
   indexBuf <- openDataBuffer (indexHash indexFile) db
   dataBuf <- openDataBuffer (dataHash indexFile) db
 

--- a/src/Database/Kioku/Schema.hs
+++ b/src/Database/Kioku/Schema.hs
@@ -22,9 +22,9 @@ querySchema idxName kQuery schema =
     Nothing -> error $ "Missing index in Kioku schema: " ++ idxName
     Just (indexBuf, dataBuf) -> runQuery kQuery indexBuf dataBuf
 
-openSchema :: SchemaName -> KiokuDB -> IO KiokuSchema
-openSchema name db = do
-  schemaFile <- throwErrors $ readSchemaFile name db
+openSchema :: KiokuNamespace -> SchemaName -> KiokuDB -> IO KiokuSchema
+openSchema namespace name db = do
+  schemaFile <- throwErrors $ readSchemaFile namespace name db
 
   buffers <- for (schemaIndexes schemaFile) $ \schemaIndex -> do
     let

--- a/test/QueryTest.hs
+++ b/test/QueryTest.hs
@@ -29,6 +29,9 @@ testDataKey (TestData bytes) = bytes
 copyTestData :: TestData -> TestData
 copyTestData (TestData bytes) = TestData (BS.copy bytes)
 
+testNamespace :: KiokuNamespace
+testNamespace = KiokuNamespace "test_namespace"
+
 test_queries :: TestTree
 test_queries =
   testGroup
@@ -38,9 +41,9 @@ test_queries =
         query' <- HH.forAll (queryGen dataset)
 
         results <- liftIO . withKiokuDB defaultKiokuPath $ \db -> do
-          void $ createDataSet "kioku_tests" dataset db
-          createIndex "kioku_tests" "kioku_tests.index" testDataKey db
-          mmappedResults <- query "kioku_tests.index" (keyExactIn $ map testDataKey query') db
+          void $ createDataSet testNamespace "kioku_tests" dataset db
+          createIndex testNamespace "kioku_tests" "kioku_tests.index" testDataKey db
+          mmappedResults <- query testNamespace "kioku_tests.index" (keyExactIn $ map testDataKey query') db
 
           let
             copiedResults = copyTestData <$> mmappedResults
@@ -131,9 +134,9 @@ data QueryTest = QueryTest
 runQueryTest :: QueryTest -> IO ()
 runQueryTest test =
   withKiokuDB defaultKiokuPath $ \db -> do
-    void $ createDataSet "kioku_tests" (queryTestData test) db
-    createIndex "kioku_tests" "kioku_tests.index" testDataKey db
-    results <- query "kioku_tests.index" (queryTestQuery test) db
+    void $ createDataSet testNamespace "kioku_tests" (queryTestData test) db
+    createIndex testNamespace "kioku_tests" "kioku_tests.index" testDataKey db
+    results <- query testNamespace "kioku_tests.index" (queryTestQuery test) db
     assertSameData (queryTestExpected test) results
 
 assertSameData :: HasCallStack => [TestData] -> [TestData] -> Assertion


### PR DESCRIPTION
This feature establishes support for multiple subtrees of objects for a multi-tenant approach. Now instead of the object directory housing the data set, index, and schema directories, it holds namespace directories that have the data set, index and schema directories for those particular namespaces.

This also cleans up some unused functions that were already broken and not used in any dependents we control.