### PR TITLE
Put -Werror only in stack.yaml

### DIFF
--- a/kioku.cabal
+++ b/kioku.cabal
@@ -32,7 +32,7 @@ library
       src
   default-extensions:
       OverloadedStrings
-  ghc-options: -Wall -Wcompat -fprof-late -Werror
+  ghc-options: -Wall -Wcompat -fprof-late
   build-depends:
       base >=4.8
     , base16-bytestring
@@ -61,7 +61,7 @@ executable kioku-benchmarks
       Paths_kioku
   default-extensions:
       OverloadedStrings
-  ghc-options: -Wall -Wcompat -fprof-late -Werror -O3 -rtsopts
+  ghc-options: -Wall -Wcompat -fprof-late -O3 -rtsopts
   build-depends:
       base >=4.8
     , bytestring
@@ -80,7 +80,7 @@ executable kioku-example
   default-extensions:
       OverloadedStrings
       RecordWildCards
-  ghc-options: -Wall -Wcompat -fprof-late -Werror -O3
+  ghc-options: -Wall -Wcompat -fprof-late -O3
   build-depends:
       base >=4.8
     , bytestring
@@ -100,7 +100,7 @@ test-suite kioku-test
       test
   default-extensions:
       OverloadedStrings
-  ghc-options: -Wall -Wcompat -fprof-late -Werror -O3
+  ghc-options: -Wall -Wcompat -fprof-late -O3
   build-depends:
       base >=4.8
     , bytestring

--- a/package.yaml
+++ b/package.yaml
@@ -12,7 +12,6 @@ ghc-options:
 - -Wall
 - -Wcompat
 - -fprof-late
-- -Werror
 when:
   - condition: impl (ghc >= 9.8)
     ghc-options:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,8 @@
 resolver: lts-24.12
 
+ghc-options:
+  "$locals": -Werror
+
 packages:
 - .
 


### PR DESCRIPTION
`-Werror` in the hpack/cabal file is fragile because we do not know which
warnings are added to GHC in the future. Similarily to other projects, let's
put this flag in the `stack.yaml` instead. We will still know of issues during
development, but consumers of the package can use Kioku without having to worry
about the warnings in the implementation of Kioku itself.
